### PR TITLE
[GRT-81-MOD] 서비스명 영문에서 한글로 교체

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata, Viewport } from "next";
 import "@/app/globals.css";
 
 export const metadata: Metadata = {
-  title: "Glit",
-  description: "KUSITMS 33rd 밋업 프로젝트 Glit",
+  title: "글릿",
+  description: "KUSITMS 33rd 밋업 프로젝트 글릿",
   manifest: "/manifest.webmanifest",
   openGraph: {
     images: ["/og-image.png"],
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",
-    title: "Glit",
+    title: "글릿",
   },
 };
 

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -2,9 +2,9 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "Glit",
-    short_name: "Glit",
-    description: "KUSITMS 33rd 밋업 프로젝트 Glit",
+    name: "글릿",
+    short_name: "글릿",
+    description: "KUSITMS 33rd 밋업 프로젝트 글릿",
     start_url: "/",
     display: "standalone",
     background_color: "#111111",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,5 @@
 const page = () => {
-  return (
-    <>
-      <p className="head-1 text-error-primary">Glit</p>
-    </>
-  );
+  return <div className="text-sea-blue-600 head-1">글릿</div>;
 };
 
 export default page;


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #34 

## 👩🏻‍💻 작업 사항

서비스명을 영문 `Glit`에서 한글 `글릿`으로 전체 교체했습니다.
- `layout.tsx`: metadata title, description, appleWebApp title 수정
- `manifest.ts`: name, short_name, description 수정  


## 📢 기타(공유 사항)

<!-- 공유할 내용, 추가 논의가 필요한 사항, 배포 시 유의사항 등을 작성해주세요. -->
OG 태그와 PWA 설치 시 보이는 타이틀명은 배포 후에 보일 것 같습니다!