### PR TITLE
[GRT-116-FEAT] 마이페이지 퍼블리싱

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -28,6 +28,14 @@ const nextConfig: NextConfig = {
       },
     },
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cdn.groute.app",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,5 +1,29 @@
+import Header from "@/components/common/Header";
+import NavigationBar from "@/components/common/NavigationBar";
+import MenuSection from "@/components/my/MenuSection";
+import ProfileSection from "@/components/my/ProfileSection";
+import { mockUserProfile } from "@/data/user/user";
+
 const Page = () => {
-  return <div></div>;
+  return (
+    <div className="flex h-full flex-col">
+      <Header title="마이페이지" leftIcon={null} />
+
+      <div className="scrollbar-hide mt-2 flex-1 overflow-y-auto px-5">
+        <div className="flex flex-col items-center gap-8">
+          <ProfileSection
+            profileImage={mockUserProfile.profileImage}
+            nickname={mockUserProfile.nickname}
+            jobRole={mockUserProfile.jobRole}
+            userStatus={mockUserProfile.userStatus}
+          />
+          <MenuSection />
+        </div>
+      </div>
+
+      <NavigationBar />
+    </div>
+  );
 };
 
 export default Page;

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -4,7 +4,7 @@ import MenuSection from "@/components/my/MenuSection";
 import ProfileSection from "@/components/my/ProfileSection";
 import { mockUserProfile } from "@/data/user/user";
 
-const Page = () => {
+const page = () => {
   return (
     <div className="flex h-full flex-col">
       <Header title="마이페이지" leftIcon={null} />
@@ -26,4 +26,4 @@ const Page = () => {
   );
 };
 
-export default Page;
+export default page;

--- a/src/components/my/MenuSection.tsx
+++ b/src/components/my/MenuSection.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { ChevronRightIcon } from "@/assets/icons";
+import Modal from "@/components/common/Modal";
+import { MENU_ITEMS } from "@/constants/my";
+import { useAuthStore } from "@/store/authStore";
+
+const STYLES = {
+  menuRow: "flex w-full items-center justify-between py-3 pl-1 cursor-pointer",
+  menuLabel: "body-2 text-gray-300",
+  menuIcon: "size-6 text-gray-700",
+} as const;
+
+const MenuSection = () => {
+  const router = useRouter();
+  const clearTokens = useAuthStore(state => state.clearTokens);
+  const [isLogoutOpen, setIsLogoutOpen] = useState(false);
+  const [isWithdrawOpen, setIsWithdrawOpen] = useState(false);
+
+  const handleMenuAction = (action: "logout" | "withdraw") => {
+    if (action === "logout") setIsLogoutOpen(true);
+    else setIsWithdrawOpen(true);
+  };
+
+  const handleLogoutConfirm = () => {
+    clearTokens();
+    router.push("/auth");
+  };
+
+  return (
+    <>
+      <div className="flex w-full flex-col">
+        {MENU_ITEMS.map(item => {
+          if ("href" in item) {
+            return (
+              <Link key={item.label} href={item.href} className={STYLES.menuRow}>
+                <span className={STYLES.menuLabel}>{item.label}</span>
+                <ChevronRightIcon className={STYLES.menuIcon} />
+              </Link>
+            );
+          }
+
+          return (
+            <button
+              key={item.label}
+              type="button"
+              onClick={() => handleMenuAction(item.action)}
+              className={STYLES.menuRow}>
+              <span className={STYLES.menuLabel}>{item.label}</span>
+              <ChevronRightIcon className={STYLES.menuIcon} />
+            </button>
+          );
+        })}
+      </div>
+
+      <Modal
+        isOpen={isLogoutOpen}
+        type="double"
+        title="로그아웃 하시겠어요?"
+        btnLLabel="취소하기"
+        btnRLabel="로그아웃"
+        onBtnLClick={() => setIsLogoutOpen(false)}
+        onBtnRClick={handleLogoutConfirm}
+        onClose={() => setIsLogoutOpen(false)}
+      />
+      <Modal
+        isOpen={isWithdrawOpen}
+        type="double"
+        title="쌓아온 빛이 사라져요"
+        contents="탈퇴 시 모든 기록이 삭제되며, 다시 복구할 수 없습니다. 계속 진행하시겠어요?"
+        btnLLabel="취소하기"
+        btnRLabel="탈퇴하기"
+        onBtnLClick={() => setIsWithdrawOpen(false)}
+        onBtnRClick={() => setIsWithdrawOpen(false)}
+        onClose={() => setIsWithdrawOpen(false)}
+      />
+    </>
+  );
+};
+
+export default MenuSection;

--- a/src/components/my/ProfileSection.tsx
+++ b/src/components/my/ProfileSection.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+
+import type { UserProfile } from "@/types/user/user";
+
+type Props = Pick<UserProfile, "profileImage" | "nickname" | "jobRole" | "userStatus">;
+
+const ProfileSection = ({ profileImage, nickname, jobRole, userStatus }: Props) => {
+  return (
+    <div className="flex flex-col items-center gap-3">
+      {profileImage ? (
+        <div className="size-31 overflow-hidden rounded-full">
+          <Image
+            src={profileImage}
+            alt="프로필 이미지"
+            width={124}
+            height={124}
+            className="size-full object-cover"
+          />
+        </div>
+      ) : (
+        <div className="size-31 rounded-full bg-gray-700" />
+      )}
+      <div className="flex flex-col items-center gap-0.5">
+        <p className="head-5 text-white">{nickname}</p>
+        <p className="body-2 text-gray-700">
+          {jobRole}, {userStatus}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileSection;

--- a/src/constants/my.ts
+++ b/src/constants/my.ts
@@ -1,0 +1,12 @@
+export type MenuItemConfig =
+  | { label: string; href: string }
+  | { label: string; action: "logout" | "withdraw" };
+
+export const MENU_ITEMS: MenuItemConfig[] = [
+  { label: "프로필 관리", href: "/my/profile" },
+  { label: "서비스 이용 가이드", href: "/my/guide" },
+  { label: "알림설정", href: "/my/alarm" },
+  { label: "개인정보처리방침", href: "/my/privacy" },
+  { label: "로그아웃", action: "logout" },
+  { label: "회원탈퇴", action: "withdraw" },
+];

--- a/src/data/user/user.ts
+++ b/src/data/user/user.ts
@@ -1,0 +1,11 @@
+import type { UserProfile } from "@/types/user/user";
+
+export const mockUserProfile: UserProfile = {
+  // profileImage: "https://cdn.groute.app/static/default-character.png",
+  profileImage: null,
+  nickname: "겨례",
+  jobRole: "개발자",
+  userStatus: "재학 중",
+  consecutiveRecordDays: 8,
+  glaring: false,
+};

--- a/src/types/user/user.ts
+++ b/src/types/user/user.ts
@@ -1,0 +1,8 @@
+export interface UserProfile {
+  profileImage: string | null;
+  nickname: string;
+  jobRole: string;
+  userStatus: string;
+  consecutiveRecordDays: number;
+  glaring: boolean;
+}


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

resolves #58 

## 👩🏻‍💻 작업 사항

https://github.com/user-attachments/assets/7b756be9-8f1e-4fdf-a087-c45b082d03bf

**src/types/user/user.ts**
- 유저 프로필 타입(UserProfile) 정의
- API 스펙 필드에 맞춰서 작성

**src/data/user/user.ts** 
- 목 유저 데이터 추가
- profileImage는 목데이터는 주석처리하고 현재 null값으로 반영

**src/constants/my.ts** 
- 마이페이지 메뉴 아이템 상수 및 타입(MenuItemConfig) 정의
- 페이지 이동 아이템(href)과 모달 액션 아이템(action)으로 구분

**src/components/my/ProfileSection.tsx** 
- 프로필 이미지, 닉네임, 직군/상태를 표시하는 컴포넌트
- profileImage가 null일 경우 `bg-gray-700`표시

**src/components/my/MenuSection.tsx**  
- 메뉴 목록 및 로그아웃/회원탈퇴 모달을 포함하는 섹션 컴포넌트
- 로그아웃 확인 시 clearTokens() 호출 후 /auth로 이동
- 회원탈퇴는 추후 API 연동

**src/app/my/page.tsx** 
- 마이페이지 메인 화면 구현

**next.config.ts** 
- 프로필 이미지 원격 도메인 cdn.groute.app 허용 추가


## 📢 기타(공유 사항)
- 회원탈퇴 모달의 확인 버튼은 API 연동 아직 안했습니다 ! 
- 메뉴 항목 중 프로필 관리(/my/profile), 서비스 이용 가이드(/my/guide), 알림설정(/my/alarm), 개인정보처리방침(/my/privacy) 다음과 같이 라우터 이름 임의로 지정해두었습니다 !
- 유민쓰 PR 머지하고 충돌 확인 후에 머지하겠습니다 !
