### PR TITLE
[GRT-114-FEAT] 온보딩 관련 API 연동

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -43,6 +43,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "cdn.groute.app",
       },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
     ],
   },
 };

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect } from "react";
 
+import { getOnboardingStatus } from "@/lib/apis/user/getOnboardingStatus";
 import { useAuthStore } from "@/store/authStore";
 
 const CallbackHandler = () => {
@@ -20,8 +21,17 @@ const CallbackHandler = () => {
       return;
     }
 
-    setTokens(accessToken, refreshToken);
-    router.replace("/");
+    const handleCallback = async () => {
+      setTokens(accessToken, refreshToken);
+      try {
+        const status = await getOnboardingStatus();
+        router.replace(status?.isOnboardingCompleted ? "/" : "/onboarding");
+      } catch {
+        router.replace("/");
+      }
+    };
+
+    handleCallback();
   }, [searchParams, setTokens, router]);
 
   return null;

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -41,7 +41,7 @@ const Page = () => {
       <div className="flex flex-col items-center">
         <GlitLogo width={113} height={74} aria-label="글릿 로고" />
         <p className="body-3 text-sea-blue-700 mt-4 text-center">
-          하루 5분, 오늘의 경험을 커리어 데이터로!
+          기록할수록 선명해지는 나만의 커리어
         </p>
         <LoginMockup width={176} height={220} className="mt-8" aria-hidden />
       </div>

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -2,7 +2,6 @@ import Header from "@/components/common/Header";
 import NavigationBar from "@/components/common/NavigationBar";
 import MenuSection from "@/components/my/MenuSection";
 import ProfileSection from "@/components/my/ProfileSection";
-import { mockUserProfile } from "@/data/user/user";
 
 const page = () => {
   return (
@@ -11,12 +10,7 @@ const page = () => {
 
       <div className="scrollbar-hide mt-2 flex-1 overflow-y-auto px-5">
         <div className="flex flex-col items-center gap-8">
-          <ProfileSection
-            profileImage={mockUserProfile.profileImage}
-            nickname={mockUserProfile.nickname}
-            jobRole={mockUserProfile.jobRole}
-            userStatus={mockUserProfile.userStatus}
-          />
+          <ProfileSection />
           <MenuSection />
         </div>
       </div>

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 
+import { usePostOnboardingComplete } from "@/lib/hooks/user/usePostOnboardingComplete";
+
 import { CancelIcon } from "@/assets/icons";
 import CTA from "@/components/common/CTA";
 import Header from "@/components/common/Header";
@@ -30,6 +32,8 @@ const Page = () => {
   const [jobRole, setJobRole] = useState("");
   const [userStatus, setUserStatus] = useState("");
 
+  const { mutate, isPending } = usePostOnboardingComplete();
+
   const canProceed = useMemo(() => {
     if (step === 1) return NICKNAME_REGEX.test(nickname);
     if (step === 2) return !!jobRole;
@@ -46,8 +50,7 @@ const Page = () => {
     if (step < 3) {
       setStep(prev => (prev + 1) as Step);
     } else {
-      // TODO: API 연동 - { nickname, jobRole, userStatus }
-      router.push("/");
+      mutate({ nickname, jobRole, userStatus }, { onSuccess: () => router.replace("/") });
     }
   };
 
@@ -114,7 +117,7 @@ const Page = () => {
       </section>
 
       <div className="px-5 pb-10">
-        <CTA disabled={!canProceed} onClick={handleNext}>
+        <CTA disabled={!canProceed || isPending} onClick={handleNext}>
           다음으로
         </CTA>
       </div>

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -3,8 +3,6 @@
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 
-import { usePostOnboardingComplete } from "@/lib/hooks/user/usePostOnboardingComplete";
-
 import { CancelIcon } from "@/assets/icons";
 import CTA from "@/components/common/CTA";
 import Header from "@/components/common/Header";
@@ -14,6 +12,7 @@ import OnboardingStepHeader from "@/components/onboarding/OnboardingStepHeader";
 import SelectionCardGrid from "@/components/onboarding/SelectionCardGrid";
 import { NICKNAME_CHARS_REGEX, NICKNAME_REGEX } from "@/constants/regex";
 import { JOB_OPTIONS, STATUS_OPTIONS } from "@/data/onboarding";
+import { usePostOnboardingComplete } from "@/lib/hooks/user/usePostOnboardingComplete";
 
 type Step = 1 | 2 | 3;
 

--- a/src/components/my/ProfileSection.tsx
+++ b/src/components/my/ProfileSection.tsx
@@ -1,10 +1,12 @@
+"use client";
+
 import Image from "next/image";
 
-import type { UserProfile } from "@/types/user/user";
+import { useGetMe } from "@/lib/hooks/user/useGetMe";
 
-type Props = Pick<UserProfile, "profileImage" | "nickname" | "jobRole" | "userStatus">;
-
-const ProfileSection = ({ profileImage, nickname, jobRole, userStatus }: Props) => {
+const ProfileSection = () => {
+  const { data: profile } = useGetMe();
+  const { profileImage, nickname, jobRole, userStatus } = profile ?? {};
   return (
     <div className="flex flex-col items-center gap-3">
       {profileImage ? (

--- a/src/lib/apis/user/getMe.ts
+++ b/src/lib/apis/user/getMe.ts
@@ -1,0 +1,4 @@
+import { api } from "@/api/api";
+import type { UserProfile } from "@/types/user/user";
+
+export const getMe = () => api.get<UserProfile>("/api/users/me");

--- a/src/lib/apis/user/getOnboardingStatus.ts
+++ b/src/lib/apis/user/getOnboardingStatus.ts
@@ -1,0 +1,4 @@
+import { api } from "@/api/api";
+import type { OnboardingStatus } from "@/types/user/onboarding";
+
+export const getOnboardingStatus = () => api.get<OnboardingStatus>("/api/onboarding/status");

--- a/src/lib/apis/user/postOnboardingComplete.ts
+++ b/src/lib/apis/user/postOnboardingComplete.ts
@@ -1,0 +1,5 @@
+import { api } from "@/api/api";
+import type { OnboardingRequest, OnboardingResponse } from "@/types/user/onboarding";
+
+export const postOnboardingComplete = (body: OnboardingRequest) =>
+  api.post<OnboardingResponse>("/api/onboarding/complete", body);

--- a/src/lib/hooks/user/useGetMe.ts
+++ b/src/lib/hooks/user/useGetMe.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getMe } from "@/lib/apis/user/getMe";
+
+export const useGetMe = () =>
+  useQuery({
+    queryKey: ["me"],
+    queryFn: getMe,
+  });

--- a/src/lib/hooks/user/usePostOnboardingComplete.ts
+++ b/src/lib/hooks/user/usePostOnboardingComplete.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { postOnboardingComplete } from "@/lib/apis/user/postOnboardingComplete";
+import type { OnboardingRequest } from "@/types/user/onboarding";
+
+export const usePostOnboardingComplete = () =>
+  useMutation({
+    mutationFn: (body: OnboardingRequest) => postOnboardingComplete(body),
+  });

--- a/src/types/user/onboarding.ts
+++ b/src/types/user/onboarding.ts
@@ -1,0 +1,13 @@
+import type { UserProfile } from "./user";
+
+export interface OnboardingStatus {
+  isOnboardingCompleted: boolean;
+}
+
+export interface OnboardingRequest {
+  nickname: string;
+  jobRole: string;
+  userStatus: string;
+}
+
+export type OnboardingResponse = UserProfile;


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

resolves #56 

## 👩🏻‍💻 작업 사항

<img width="3420" height="1964" alt="image" src="https://github.com/user-attachments/assets/23a4d57c-a1f4-4c59-a9ba-7c79011c2076" />
<img width="3420" height="1964" alt="image" src="https://github.com/user-attachments/assets/6ad95180-eccd-4345-904a-af8f8e2b65da" />

### 온보딩 API 연동

**src/types/user/onboarding.ts**
- 온보딩 관련(온보딩 완료 여부 조회, 온보딩 완료) 타입 추가

**src/lib/apis/user/getOnboardingStatus.ts** , **src/lib/hooks/user/usePostOnboardingComplete.ts**
- `GET /api/onboarding/status` : 온보딩 완료 여부 조회 API 추가
- `POST /api/onboarding/complete` : 온보딩 완료 API 추가

**로직**
- 로그인 후 `/auth/callback` 에서 온보딩 완료 여부를 확인하여 미완료 시 `/onboarding`, 완료 시 `/` 로 분기 처리
- 온보딩 3단계(닉네임 → 직군 → 직업 상태) 완료 시 API 호출 후 홈으로 이동

--- 

### 내 정보 조회 API 연동

**src/lib/apis/user/getMe.ts** 
- `GET /api/users/me` 내 정보 조회 API 추가

**src/lib/hooks/user/useGetMe.ts**
- 내 정보 조회 useQuery 훅 추가

**src/app/my/page.tsx**
- 서버 컴포넌트 유지, 데이터 페칭 책임 ProfileSection으로 이동

**src/components/my/ProfileSection.tsx** 
- useGetMe 훅 내장, 프로필 실제 데이터 연동

---

### 로그인 화면
- 로그인 화면 캐치프레이즈 변경


## 📢 기타(공유 사항)
- 현재 내정보조회 시 avatars.githubusercontent.com 이미지 도메인으로 내려오고 있어서 추가해두었습니다. 추후 내려오는 이미지 경로 정리해서 수정해두겠습니다 !
