### PR TITLE
[FIX] 캘린더 안내 오버레이 세션 내 재노출 오류 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,8 @@ const Page = () => {
     () => false,
   );
   const [dismissed, setDismissed] = useState(
-    () => sessionStorage.getItem("calendarGuideDismissed") === "true",
+    () =>
+      typeof window !== "undefined" && sessionStorage.getItem("calendarGuideDismissed") === "true",
   );
   const showCalendarGuide = isFirstStar && !dismissed;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,8 +26,15 @@ const Page = () => {
     () => sessionStorage.getItem("isFirstStar") === "true",
     () => false,
   );
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissed, setDismissed] = useState(
+    () => sessionStorage.getItem("calendarGuideDismissed") === "true",
+  );
   const showCalendarGuide = isFirstStar && !dismissed;
+
+  const handleDismissCalendarGuide = () => {
+    sessionStorage.setItem("calendarGuideDismissed", "true");
+    setDismissed(true);
+  };
 
   const handleFirstClick = () => {
     if (typeof window === "undefined") return;
@@ -45,13 +52,14 @@ const Page = () => {
           type="button"
           aria-label="캘린더 안내 닫기"
           className="absolute inset-0 z-10 bg-gray-900/70"
-          onClick={() => setDismissed(true)}
+          onClick={handleDismissCalendarGuide}
         />
       ) : null}
       <div className="scrollbar-hide flex-1 overflow-y-auto px-5 pt-12 pb-6">
         <p className="head-5 pb-3.5 text-center text-white">
           오늘의 경험을 기록하고 <br />
-          <span suppressHydrationWarning>{me?.nickname ?? ""}</span>님의 강점을 확인해보세요
+          <span suppressHydrationWarning>{me?.nickname ?? ""}</span>
+          님의 강점을 확인해보세요
         </p>
         <div className="relative mx-auto w-fit">
           {me?.glaring && (


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #102

## 👩🏻‍💻 작업 사항

### 문제
- 캘린더 안내 오버레이(`showCalendarGuide`)를 닫은 후 다른 페이지로 이동했다가 홈으로 돌아오면 오버레이가 다시 표시되는 문제
- dismissed 상태를 `useState(false)`로만 관리하고 있어, 페이지 이동 시 컴포넌트가 언마운트,재마운트되면서 항상 false로 초기화되기 때문

### 해결
- useState 초기값을 sessionStorage에서 읽어오도록 변경 (`calendarGuideDismissed`)
- dismiss 시 sessionStorage에도 함께 저장하는 `handleDismissCalendarGuide` 핸들러 추출
- 이로써 세션이 유지되는 동안은 한 번 닫은 오버레이가 다시 표시되지 않으며, 탭을 닫으면 초기화되어 다음 세션에서는 정상 동작

## 📢 기타(공유 사항)

<!-- 공유할 내용, 추가 논의가 필요한 사항, 배포 시 유의사항 등을 작성해주세요. -->
