### PR TITLE
[FIX] 캘린더 스와이프 높이를 직접 계산하도록 수정

### DIFF
--- a/src/components/calendar/CalendarSwiper.tsx
+++ b/src/components/calendar/CalendarSwiper.tsx
@@ -2,7 +2,7 @@
 
 import "swiper/css";
 
-import { useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import type { Swiper as SwiperType } from "swiper";
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -29,13 +29,36 @@ const CalendarSwiper = ({
   const [baseMonth, setBaseMonth] = useState<Date>(
     () => new Date(today.getFullYear(), today.getMonth()),
   );
+  const [swiperHeight, setSwiperHeight] = useState<number>();
   const isResettingRef = useRef(false);
+  const swiperRef = useRef<SwiperType | null>(null);
+  const slideContentRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   const slideMonths = [
     new Date(baseMonth.getFullYear(), baseMonth.getMonth() - 1),
     baseMonth,
     new Date(baseMonth.getFullYear(), baseMonth.getMonth() + 1),
   ];
+
+  const updateHeight = (index = swiperRef.current?.activeIndex ?? 1) => {
+    const target = slideContentRefs.current[index];
+
+    if (!target) return;
+
+    setSwiperHeight(Math.ceil(target.getBoundingClientRect().height));
+  };
+
+  useLayoutEffect(() => {
+    updateHeight(1);
+
+    const target = slideContentRefs.current[1];
+    if (!target) return;
+
+    const observer = new ResizeObserver(() => updateHeight(1));
+    observer.observe(target);
+
+    return () => observer.disconnect();
+  }, [baseMonth]);
 
   const handleTransitionEnd = (swiper: SwiperType) => {
     if (isResettingRef.current || swiper.activeIndex === 1) return;
@@ -47,24 +70,42 @@ const CalendarSwiper = ({
       setBaseMonth(nextBaseMonth);
     });
     swiper.slideTo(1, 0, false);
-    swiper.updateAutoHeight(0);
+    requestAnimationFrame(() => updateHeight(1));
     isResettingRef.current = false;
     onMonthChange?.(nextBaseMonth);
   };
 
   return (
     <>
-      <Swiper initialSlide={1} speed={250} autoHeight onTransitionEnd={handleTransitionEnd}>
+      <Swiper
+        initialSlide={1}
+        speed={250}
+        onSwiper={swiper => {
+          swiperRef.current = swiper;
+          requestAnimationFrame(() => updateHeight(swiper.activeIndex));
+        }}
+        onSlideChange={swiper => updateHeight(swiper.activeIndex)}
+        onTransitionEnd={handleTransitionEnd}
+        style={{
+          height: swiperHeight ? `${swiperHeight}px` : undefined,
+          transition: "height 250ms ease",
+        }}>
         {slideMonths.map((month, i) => (
           <SwiperSlide key={i}>
-            <Calendar
-              type="page"
-              mode="single"
-              month={month}
-              selected={selectedDate}
-              onSelect={onSelect}
-              modifiers={{ calendar: scrumDates, exceeded: exceededMatcher, otherSelected: today }}
-            />
+            <div ref={element => void (slideContentRefs.current[i] = element)}>
+              <Calendar
+                type="page"
+                mode="single"
+                month={month}
+                selected={selectedDate}
+                onSelect={onSelect}
+                modifiers={{
+                  calendar: scrumDates,
+                  exceeded: exceededMatcher,
+                  otherSelected: today,
+                }}
+              />
+            </div>
           </SwiperSlide>
         ))}
       </Swiper>


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

resolves #121 

## 👩🏻‍💻 작업 사항

- 높이 감지를 `autoheight` 속성으로 적용했던 것을 직접 계산 -> `swiperHeight`

## 📢 기타(공유 사항)

- 제발요
