### PR TITLE
[FIX] 홈/마이페이지 QA 반영

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,7 +63,7 @@ const Page = () => {
         />
       ) : null}
       <div className="scrollbar-hide flex-1 overflow-y-auto px-5 pt-12 pb-6">
-        <p className="head-5 pb-3.5 text-center text-white">
+        <p className="head-5 relative z-10 pb-3.5 text-center text-white">
           오늘의 경험을 기록하고 <br />
           <span suppressHydrationWarning>{me?.nickname ?? ""}</span>
           님의 강점을 확인해보세요

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 
 import CharacterHome from "@/assets/images/home/character_home.svg";
 import CharacterHomeGlaring from "@/assets/images/home/character_home_glaring.svg";
@@ -15,12 +15,18 @@ import NotificationPermission, {
 import SpeechBubble from "@/components/home/SpeechBubble";
 import HeatmapSection from "@/containers/home/HeatmapSection";
 import RadarChartSection from "@/containers/home/RadarChartSection";
-import { useMe } from "@/lib/hooks/user/userClient";
+import { useInvalidateMe, useMe } from "@/lib/hooks/user/userClient";
 
 const noop = () => () => {};
 
 const Page = () => {
+  const invalidateMe = useInvalidateMe();
   const { data: me } = useMe();
+
+  useEffect(() => {
+    invalidateMe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const isFirstStar = useSyncExternalStore(
     noop,
     () => sessionStorage.getItem("isFirstStar") === "true",

--- a/src/constants/my.ts
+++ b/src/constants/my.ts
@@ -18,7 +18,10 @@ export const MENU_ITEMS: MenuItemConfig[] = [
   { label: "프로필 관리", href: "/my/profile" },
   { label: "서비스 이용 가이드", href: "/my/guide" },
   { label: "알림설정", href: "/my/alarm" },
-  { label: "개인정보처리방침", href: "/my/privacy" },
+  {
+    label: "개인정보처리방침",
+    href: "https://pie-adapter-6d6.notion.site/36edf277bb9880579bf2c487f834c58b",
+  },
   { label: "로그아웃", action: "logout" },
   { label: "회원탈퇴", action: "withdraw" },
 ];

--- a/src/containers/auth/SocialLoginSection.tsx
+++ b/src/containers/auth/SocialLoginSection.tsx
@@ -43,7 +43,13 @@ const SocialLoginSection = () => {
           onClick={() => handleLogin(provider)}
         />
       ))}
-      <p className="body-4 text-center text-gray-500">개인정보 처리방침</p>
+      <a
+        href="https://pie-adapter-6d6.notion.site/36edf277bb9880579bf2c487f834c58b"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="body-4 text-center text-gray-500">
+        개인정보 처리방침
+      </a>
     </div>
   );
 };

--- a/src/containers/my/profile/ProfileForm.tsx
+++ b/src/containers/my/profile/ProfileForm.tsx
@@ -83,7 +83,7 @@ const ProfileForm = ({ initialProfile }: ProfileFormProps) => {
               disabled={!isEditing}
               maxLength={12}
               className="h-9.75 p-2"
-              textareaClassName="h-5.75"
+              textareaClassName="h-5.75 mt-0.5 ml-1"
               showCount={false}
               onChange={isEditing ? val => setNickname(val) : undefined}
               onBlur={isEditing ? () => setNicknameTouched(true) : undefined}

--- a/src/containers/my/profile/ProfileForm.tsx
+++ b/src/containers/my/profile/ProfileForm.tsx
@@ -49,6 +49,7 @@ const ProfileForm = ({ initialProfile }: ProfileFormProps) => {
     await patchMe({ jobRole, userStatus });
     setProfile({ nickname, jobRole, userStatus });
     setIsEditing(false);
+    router.refresh();
   };
 
   const handleBack = () => {


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #113 

## 👩🏻‍💻 작업 사항

### 버그 수정
- 홈 페이지 닉네임/캐릭터 최신화: 다른 페이지 방문 후 돌아올 때 useMe 캐시가 갱신되지 않던 문제 수정 — 마운트 시 invalidateMe() 호출
- 홈 페이지 글로잉 블러와 텍스트 겹침: 닉네임 텍스트가 블러 이미지에 가려져 뿌옇게 보이던 문제 수정 — relative z-10 추가
- 프로필 수정 후 마이페이지 즉각 반영: 프로필 저장 후 router.refresh() 호출로 바로 반영되도록 수정

### 개선
- 개인정보 처리방침 링크 연결: 마이페이지 메뉴 및 소셜 로그인 하단의 개인정보 처리방침을 실제 Notion 링크로 연결 (기존: 텍스트만 표시)
- 프로필 닉네임 필드 여백 조정: 텍스트 입력 영역에 mt-0.5 ml-1 추가

## 📢 기타(공유 사항)

<!-- 공유할 내용, 추가 논의가 필요한 사항, 배포 시 유의사항 등을 작성해주세요. -->
